### PR TITLE
Add CD-ROM support

### DIFF
--- a/developer/bin/start-sheepshaver
+++ b/developer/bin/start-sheepshaver
@@ -1,7 +1,13 @@
 #!/bin/bash
+if [ ! -z $SS_CDROM ]
+then
+  CD="--cdrom $SS_CDROM"
+fi
+
 padsp SheepShaver \
       --rom $SS_ROM \
       --disk $SS_DISK \
+      $CD \
       --extfs /shared \
       --ramsize $SS_RAM \
       --screen win/$SS_WIDTH/$SS_HEIGHT \

--- a/run
+++ b/run
@@ -13,6 +13,9 @@ SS_ROM=/data/sheepshaver.rom
 # path within your SS_DATA_PATH to your hard disk file
 SS_DISK=/data/disk
 
+# path within your SS_DATA_PATH to a CD image (empty for none)
+SS_CDROM=
+
 # amount of RAM to allocat (256MB)
 SS_RAM=268435456
 

--- a/run
+++ b/run
@@ -13,7 +13,7 @@ SS_ROM=/data/sheepshaver.rom
 # path within your SS_DATA_PATH to your hard disk file
 SS_DISK=/data/disk
 
-# amount of RAM to allocat (64MB)
+# amount of RAM to allocat (256MB)
 SS_RAM=268435456
 
 # width of the emulated display


### PR DESCRIPTION
This adds the option to pass in a CD-ROM file to be used in the emulator (useful for installing).

I was actually unable to rebuild the Docker image due to Debian Wheezy being EOL.  However, I was able to test that this worked by monkey patching the modified scripts over the existing image.  This can be done with a simple Dockerfile:

```
FROM cmiles74/docker-sheepshaver
COPY start-sheepshaver /developer/bin/
USER developer
entrypoint ["/developer/bin/start-sheepshaver"]
```